### PR TITLE
fix: make timer reset compatible with stdlib

### DIFF
--- a/time.go
+++ b/time.go
@@ -98,7 +98,7 @@ func (t *Time) stopTimer(id int) bool {
 
 	_, ok := t.moments[id]
 	delete(t.moments, id)
-	return !ok
+	return ok
 }
 
 func (t *Time) resetTimer(d time.Duration, id int, ch chan time.Time) {

--- a/time_test.go
+++ b/time_test.go
@@ -101,6 +101,35 @@ func TestTime_Timer(t *testing.T) {
 	}
 }
 
+func TestTime_TimerReset(t *testing.T) {
+	now := time.Date(2049, 5, 6, 23, 55, 11, 1034, time.UTC)
+	sim := NewTime(now)
+
+	after := sim.Timer(time.Second)
+	defer after.Stop()
+
+	if !after.Stop() {
+		t.Error("unexpected state")
+	}
+	after.Reset(time.Second)
+
+	select {
+	case <-after.C():
+		t.Error("unexpected done")
+	default:
+	}
+
+	sim.Travel(time.Second)
+	select {
+	case <-after.C():
+	default:
+		t.Error("unexpected state")
+	}
+	if after.Stop() {
+		t.Error("unexpected state")
+	}
+}
+
 func TestTime_Ticker(t *testing.T) {
 	now := time.Date(2049, 5, 6, 23, 55, 11, 1034, time.UTC)
 	sim := NewTime(now)


### PR DESCRIPTION
Timer.Stop method should return `false` if the timer has already expired or been stopped. In neo, the timer may be considered expired or stopped when there is no associated `moment`.

See also `go doc time Timer.Reset` and `go doc time Timer.Stop`:
<details>

```
// If a program has already received a value from t.C, the timer is known
// to have expired and the channel drained, so t.Reset can be used directly.
// If a program has not yet received a value from t.C, however,
// the timer must be stopped and—if Stop reports that the timer expired
// before being stopped—the channel explicitly drained:
//
// 	if !t.Stop() {
// 		<-t.C
// 	}
// 	t.Reset(d)
```
```
// To ensure the channel is empty after a call to Stop, check the
// return value and drain the channel.
// For example, assuming the program has not received from t.C already:
//
// 	if !t.Stop() {
// 		<-t.C
// 	}
```
</details>

For example, the following code snippet shows when we can safely stop timer without draining the channel, reset timer without stopping it before hand, and when we must drain the channel prior to resetting the timer.

```
interval, resetInterval := time.Minute, make(chan time.Duration)

var timer clock.Timer
for {
	// Some other logic here.

	if timer == nil {
		timer = s.clock.Timer(interval)
		defer timer.Stop()
	} else {
		// At this point we know that the channel is empty.
		timer.Reset(interval)
	}

	// And some other logic there.

wait:
	select {
	case <-done:
		// Timers have buffered channels so we can safely hand
		// it over to GC without draining. Notice that we still stop
		// the timer in deferred call.
		return
	case interval = <-resetInterval:
		if !timer.Stop() {
			// Drain channel if the timer has already expired.
			<-timer.C()
		}
		timer.Reset(interval)
		goto wait
	case <-timer.C():
	}
	// Timer expired, do something.
}
```
